### PR TITLE
Switch to new service UUID used in newest firmware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aranet4-cli"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Quentin Mazars-Simon"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ a.k.a. my first rust project by following the [Command line apps in Rust](https:
 ```
 aranet4-cli get --max-devices=1
 ```
+
+Requires firmware v1.2.0 or greater.

--- a/src/aranet.rs
+++ b/src/aranet.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 use std::time;
 use uuid::Uuid;
 
-const ARANET4_SERVICE_UUID: &str = "f0cd1400-95da-4f4b-9ac8-aa55d312af0c";
+const ARANET4_SERVICE_UUID: &str = "0000fce0-0000-1000-8000-00805f9b34fb";
 const ARANET4_CHARACTERISTIC_UUID: &str = "f0cd3001-95da-4f4b-9ac8-aa55d312af0c";
 
 const BLUETOOTH_MODEL_NUMBER_CHARACTERISTIC: &str = "00002a24-0000-1000-8000-00805f9b34fb";


### PR DESCRIPTION
See https://forum.aranet.com/all-about-aranet4/aranet4-with-firmware-v.1.2.0-or-greater-integration-notes/

First reported here: https://github.com/quentinms/homebridge-aranet4/issues/15